### PR TITLE
fix: handle the case that transform_path doesn't return highlights

### DIFF
--- a/lua/sg/bufread.lua
+++ b/lua/sg/bufread.lua
@@ -90,7 +90,9 @@ M._open_remote_folder = function(bufnr, bufname, data)
         end
 
         vim.api.nvim_buf_set_lines(bufnr, start, -1, false, { line })
-        vim.api.nvim_buf_add_highlight(bufnr, ns, highlights, idx - 1, 1, 3)
+        if highlights then
+          vim.api.nvim_buf_add_highlight(bufnr, ns, highlights, idx - 1, 1, 3)
+        end
       end
     end)
 


### PR DESCRIPTION
If the user does not have `has_devicons` no highlights are returned: https://github.com/tjdevries/sg.nvim/blob/6eb1a0dbff6d52b2f3b5d9789fb7307755c8ea1f/lua/sg/directory.lua#L50-L52

This case needs to be handled.

Thanks for this nice plugin!